### PR TITLE
fix compiler error "cannot bind packed field"

### DIFF
--- a/frogwrap.cpp
+++ b/frogwrap.cpp
@@ -70,7 +70,9 @@ FrogWrap::FrogWrap(const char *uri)
   OptimFROG_getTags(decoder, &ofr_tags);
   for(uInt32_t i = 0; i < ofr_tags.keyCount; i++)
   {
-    tags.insert(std::pair<std::string, std::string>(ofr_tags.keys[i], ofr_tags.values[i]));
+    std::string key = ofr_tags.keys[i];
+    std::string value = ofr_tags.values[i];
+    tags.insert(std::pair<std::string, std::string>(key, value));
   }
   OptimFROG_freeTags(&ofr_tags);
 }


### PR DESCRIPTION
error message: `frogwrap.cpp:73:68: error: cannot bind packed field ‘ofr_tags.OptimFROG_Tags::keys[i]’ to ‘char*&’`